### PR TITLE
'fun String. toLowerCase(): String' is deprecated. Use lowercase() instead.

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ fun isSystemInDarkTheme(): Boolean = when {
     }
     HAS_DCONF -> {
         val result = Dconf.getDconfEntry("/org/gnome/desktop/interface/gtk-theme")
-        result.toLowerCase().contains("dark")
+        result.lowercase().contains("dark")
     }
     else -> false
 }

--- a/src/main/java/com/github/tkuenneth/nativeparameterstoreaccess/NativeParameterStoreAccess.java
+++ b/src/main/java/com/github/tkuenneth/nativeparameterstoreaccess/NativeParameterStoreAccess.java
@@ -25,6 +25,7 @@ package com.github.tkuenneth.nativeparameterstoreaccess;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.Locale;
 
 /**
  * A couple of constants.
@@ -33,7 +34,7 @@ import java.io.InputStream;
  */
 public final class NativeParameterStoreAccess {
 
-    static final String OS_NAME_LC = System.getProperty("os.name", "").toLowerCase();
+    static final String OS_NAME_LC = System.getProperty("os.name", "").toLowerCase(Locale.ROOT);
 
     /**
      * If running on Windows, <code>true</code> otherwise <code>false</code>


### PR DESCRIPTION
Not sure if there is a character in dark that is locale dependent, but lets get rid of the lint anyway